### PR TITLE
updated headers 'Tested up to' and 'Requires at least'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WP Options Editor
 
-* Requires at least: 3.4
-* Tested up to: 4.5
+* Requires at least: 4.7.0
+* Tested up to: 4.9.7
 * Stable tag: 1.1
 * License: GPLv2 or later
 * License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: mikeselander
 Donate link: https://mikeselander.com
 Tags: wp_options, development, wp options table, edit, delete, add
-Requires at least: 3.4
-Tested up to: 4.5
+Requires at least: 4.7.0
+Tested up to: 4.9.7
 Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Requirements tested with https://wpseek.com/pluginfilecheck/

This should be done ASAP. The old headers hinder discover-ability in the wp-admin search for plugins. 