### PR TITLE
add `WPLANG` option to protected settings

### DIFF
--- a/admin/manager-page.php
+++ b/admin/manager-page.php
@@ -221,6 +221,7 @@ class OptionsManagerSettingsPage {
 			'link_manager_enabled',
 			'initial_db_version',
 			'theme_switched',
+			'WPLANG',
 		);
 		$this->wp_default_options = array(
 			'_site_transient_update_core',


### PR DESCRIPTION
Closes #25 

I added the option to vital because it wont be recovered by saving the "General Settings" screen